### PR TITLE
Fix specFilterFnDelegate bug where configuration not being called

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -17,7 +17,7 @@
         });
     }
 
-    var specFilterFnDelegate = jasmineEnv.configuration.specFilter;
+    var specFilterFnDelegate = jasmineEnv.configuration().specFilter;
     jasmineEnv.configure({ specFilter: customSpecFilter });
 
     function parseTags(tags) {


### PR DESCRIPTION
Fixing deprecated way of setting a custom `specFilter` introduced a bug where `configuration` isn't called, and thus never used. Simple fix.

Previous fix which introduced bug: https://github.com/mnasyrov/karma-jasmine-spec-tags/commit/496c65883a5f665e3fd6bffb510d74680dbe0deb
From Issue: https://github.com/mnasyrov/karma-jasmine-spec-tags/issues/1